### PR TITLE
[faux-ipcc] Use a little bit of Cargo hackery to support illumos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "CoreFoundation-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
+dependencies = [
+ "libc",
+ "mach",
+]
+
+[[package]]
+name = "IOKit-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
+dependencies = [
+ "CoreFoundation-sys",
+ "libc",
+ "mach",
+]
+
+[[package]]
 name = "abi"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/hubris#f3d51548b98fa4728d68fb3059137092c4de7ccb"
@@ -12,6 +33,15 @@ dependencies = [
  "phash",
  "serde",
  "zerocopy 0.6.6",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -508,7 +538,8 @@ dependencies = [
  "hubpack",
  "humantime",
  "ipcc-data",
- "serialport",
+ "serialport 4.2.1-alpha.0",
+ "serialport 4.7.0",
  "slog",
  "slog-async",
  "slog-term",
@@ -847,6 +878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +906,17 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -989,6 +1040,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc_version"
@@ -1128,6 +1208,22 @@ dependencies = [
 
 [[package]]
 name = "serialport"
+version = "4.2.1-alpha.0"
+source = "git+https://github.com/jgallagher/serialport-rs.git?branch=illumos-support#36c9f0e0292eac32215ab77c5847bf7afb13f000"
+dependencies = [
+ "CoreFoundation-sys",
+ "IOKit-sys",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libudev",
+ "mach2",
+ "nix 0.24.3",
+ "regex",
+ "winapi",
+]
+
+[[package]]
+name = "serialport"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
@@ -1139,7 +1235,7 @@ dependencies = [
  "io-kit-sys",
  "libudev",
  "mach2",
- "nix",
+ "nix 0.26.4",
  "scopeguard",
  "unescaper",
  "winapi",

--- a/faux-ipcc/Cargo.toml
+++ b/faux-ipcc/Cargo.toml
@@ -13,7 +13,6 @@ anyhow = "1.0.96"
 clap = { version = "4.5.31", features = ["derive", "env"] }
 corncobs = "0.1.3"
 hex = "0.4.3"
-serialport = "4.7.0"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
 ftdi = "0.1.3"
 slog-async = "2.8.0"
@@ -22,3 +21,13 @@ zerocopy = "0.8.20"
 humantime = "2.1.0"
 x509-cert = "0.2.5"
 hubpack = "0.1.2"
+
+# serialport doesn't support illumos
+[target.'cfg(not(target_os = "illumos"))'.dependencies.serialport_upstream]
+package = "serialport"
+version = "4.7.0"
+
+[target.'cfg(target_os = "illumos")'.dependencies.serialport_illumos]
+package = "serialport"
+git = "https://github.com/jgallagher/serialport-rs.git"
+branch = "illumos-support"

--- a/faux-ipcc/src/main.rs
+++ b/faux-ipcc/src/main.rs
@@ -2,6 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#[cfg(target_os = "illumos")]
+use serialport_illumos as serialport;
+
+#[cfg(not(target_os = "illumos"))]
+use serialport_upstream as serialport;
+
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand};
 use serialport::{DataBits, FlowControl, Parity, StopBits};


### PR DESCRIPTION
Currently, `serialport` support for `illumos` has not been upstreamed, however there is a [fork+branch](https://github.com/jgallagher/serialport-rs/tree/illumos-support) that adds support for it.

This PR adds two conditional and renamed dependencies for each variant (as unfortunately, cargo is unhappy JUST switching the deps based on `target_os` contents), and re-aliases the appropriate one back to the name `serialport` within the Rust source.

I don't believe there is a less-hacky way to do this, however it at least compiles as-is. Attempts to test this led to an unfortunate serial port kernel lockup, but I am unsure whether that is the fault of the patched `serialport` crate, or a latent kernel bug wrt serial port handling. I'll report back when I HAVE successfully tested this.